### PR TITLE
Fix problem in url redirect

### DIFF
--- a/src/js/CoachmarkApi.js
+++ b/src/js/CoachmarkApi.js
@@ -13,6 +13,7 @@ export default class CoachmarkApi {
 	 * Gets a coachmark by id
 	 **/
 	getCoachmark(cmId) {
+		console.log('Entering getCoachmark with cmId: ', cmId);
 		const request = new Request(this.url + '/coachmark/' + cmId, {
 			method: 'GET',
 			mode: 'cors',
@@ -24,9 +25,11 @@ export default class CoachmarkApi {
 		return new Promise((resolve, reject) => {
 			fetch(request)
 				.then((response) => {
+					console.log('Got response: ', response.body);
 					return response.ok ? resolve(response.json()) : reject(Error(`GET ${response.url} ${response.statusText} (${response.status})`));
 				})
 				.catch((error) => {
+					console.log('Rejecting with error: ', error);
 					return reject(Error(error));
 				});
 		});


### PR DESCRIPTION
The originally reported issue for 282 is happening because console doesn't have config for the coachmark api yet.  No code changes are needed on our end. However, I uncovered a bug while testing this which I'm fixing in this branch.  Also adding additional logging to help in troubleshooting in the future (console.log is being stripped by webpack)